### PR TITLE
Add build-and-deploy GitHub Action

### DIFF
--- a/.github/workflows/build-deploy.yaml
+++ b/.github/workflows/build-deploy.yaml
@@ -1,0 +1,62 @@
+name: Build and Deploy
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'Dockerfile'
+      - 'pyproject.toml'
+      - 'uv.lock'
+      - '.dockerignore'
+      - '.github/workflows/build-deploy.yaml'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@main
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: |
+            ghcr.io/rneopets/jukebot:latest
+            ghcr.io/rneopets/jukebot:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to Vultr
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.VULTR_HOST }}
+          username: ${{ secrets.VULTR_SSH_USER }}
+          key: ${{ secrets.VULTR_SSH_KEY }}
+          command_timeout: 15m
+          script: |
+            cd /opt/bots/jukebot
+            git pull
+            docker compose pull
+            pm2 restart jukebot

--- a/README.md
+++ b/README.md
@@ -10,11 +10,23 @@ To run this project, you will need to add the following environment variables to
 
 ## Deployment
 
-To deploy this project, run
+Jukebot runs pm2-managed on the Vultr box at `/opt/bots/jukebot`
+(`ecosystem.config.js` runs `docker compose up`).
 
-```bash
-docker compose up
-```
+Pushing a change to `Dockerfile`, `pyproject.toml`, `uv.lock`, or
+`.dockerignore` on `master` triggers
+`.github/workflows/build-deploy.yaml`, which builds and pushes
+`ghcr.io/rneopets/jukebot` to GHCR, then SSHes into the Vultr box and runs
+`git pull && docker compose pull && pm2 restart jukebot`. It can also be
+run manually via `workflow_dispatch`.
+
+Ordinary code-only changes (no Dockerfile/dependency changes) don't need
+the Action at all - the container bind-mounts the repo (`./:/app` in
+`docker-compose.yaml`), so a plain `git pull` + `pm2 restart jukebot` on
+the box picks them up without a rebuild.
+
+Required secrets on the repo: `VULTR_HOST`, `VULTR_SSH_USER`,
+`VULTR_SSH_KEY`.
 
 ## Notes
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,5 +1,6 @@
 services:
   jukebot:
+    image: ghcr.io/rneopets/jukebot:latest
     build: .
     volumes:
       - ./:/app

--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -1,0 +1,12 @@
+module.exports = {
+  apps: [
+    {
+      name: "jukebot",
+      script: "docker",
+      args: ["compose", "up"],
+      cwd: "/opt/bots/jukebot/",
+      autorestart: true,
+      restart_delay: 1000,
+    },
+  ],
+};


### PR DESCRIPTION
## Summary
- Build the Docker image and push to `ghcr.io/rneopets/jukebot` on pushes to `master` that touch `Dockerfile`, `pyproject.toml`, `uv.lock`, or `.dockerignore` (or via manual `workflow_dispatch`)
- SSH into the Vultr box and run `git pull && docker compose pull && pm2 restart jukebot`, mirroring neobot's deploy setup
- Add `ecosystem.config.js` so jukebot is pm2-managed like neobot
- Add an `image:` tag to `docker-compose.yaml` so `docker compose pull` has something to pull
- Update the README's Deployment section to document the actual flow