### PR TITLE
Fail deploy step if any command errors

### DIFF
--- a/.github/workflows/build-deploy.yaml
+++ b/.github/workflows/build-deploy.yaml
@@ -56,6 +56,7 @@ jobs:
           key: ${{ secrets.VULTR_SSH_KEY }}
           command_timeout: 15m
           script: |
+            set -e
             cd /opt/bots/jukebot
             git pull
             docker compose pull


### PR DESCRIPTION
## Summary
- Add \`set -e\` to the deploy script's remote script so a failed \`docker compose pull\` (or any other step) actually fails the job, instead of being masked by a successful \`pm2 restart\` afterward